### PR TITLE
refactor: auth guard returns url tree instead of false + side effect

### DIFF
--- a/projects/ccc-lib/auth-authentication-guard/authentication.guard.ts
+++ b/projects/ccc-lib/auth-authentication-guard/authentication.guard.ts
@@ -75,7 +75,6 @@ export const LoginAuthenticationGuard: CanActivateFn = (
       return setRedirectAndGetLoginUrlTree(authService, router, routerState.url);
     }),
     catchError(() => {
-      authService.redirectUrl.set(routerState.url);
       return setRedirectAndGetLoginUrlTree(authService, router, routerState.url);
     }),
   );
@@ -91,19 +90,3 @@ const setRedirectAndGetLoginUrlTree = (authService: AuthService, router: Router,
   authService.redirectUrl.set(redirectUrl);
   return of(router.createUrlTree([authService.loginRoute()]));
 };
-
-// TODO [This PR]: Decide between that helper function and writing those two lines twice
-// return authService.checkUserSession().pipe(
-//     switchMap((sessionInfo) => {
-//       if (sessionInfo?.authenticated) {
-//         return of(true);
-//       }
-
-//       authService.redirectUrl.set(routerState.url);
-//       return of(router.createUrlTree([authService.loginRoute()]));
-//     }),
-//     catchError(() => {
-//       authService.redirectUrl.set(routerState.url);
-//       return of(router.createUrlTree([authService.loginRoute()]));
-//     }),
-//   );

--- a/projects/ccc-lib/auth-authentication-guard/authentication.guard.ts
+++ b/projects/ccc-lib/auth-authentication-guard/authentication.guard.ts
@@ -1,9 +1,9 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot } from '@angular/router';
 import { AuthService } from '@cccteam/ccc-lib/auth-service';
 import { API_URL, BASE_URL } from '@cccteam/ccc-lib/types';
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 
 /**
  * Route guard that protects routes using OIDC (OpenID Connect) authentication.
@@ -55,34 +55,55 @@ export const OIDCAuthenticationGuard = (
  * user can be redirected back after successful login.
  *
  */
-export const LoginAuthenticationGuard = (
+export const LoginAuthenticationGuard: CanActivateFn = (
   _: ActivatedRouteSnapshot,
   routerState: RouterStateSnapshot,
-): Observable<boolean> => {
+) => {
   const router = inject(Router);
   const authService = inject(AuthService);
-
-  const authenticate = (): void => {
-    authService.redirectUrl.set(routerState.url);
-    router.navigate([authService.loginRoute()]);
-  };
 
   if (authService.authenticated()) {
     return of(true);
   }
 
   return authService.checkUserSession().pipe(
-    map((sessionInfo) => {
+    switchMap((sessionInfo) => {
       if (sessionInfo?.authenticated) {
-        return true;
+        return of(true);
       }
 
-      authenticate();
-      return false;
+      return setRedirectAndGetLoginUrlTree(authService, router, routerState.url);
     }),
     catchError(() => {
-      authenticate();
-      return of(false);
+      authService.redirectUrl.set(routerState.url);
+      return setRedirectAndGetLoginUrlTree(authService, router, routerState.url);
     }),
   );
 };
+
+/**
+ * Impure function used to handle redirecting user to login
+ *
+ * Has the side effect of storing the url the user wished to access
+ * in AuthService
+ */
+const setRedirectAndGetLoginUrlTree = (authService: AuthService, router: Router, redirectUrl: string) => {
+  authService.redirectUrl.set(redirectUrl);
+  return of(router.createUrlTree([authService.loginRoute()]));
+};
+
+// TODO [This PR]: Decide between that helper function and writing those two lines twice
+// return authService.checkUserSession().pipe(
+//     switchMap((sessionInfo) => {
+//       if (sessionInfo?.authenticated) {
+//         return of(true);
+//       }
+
+//       authService.redirectUrl.set(routerState.url);
+//       return of(router.createUrlTree([authService.loginRoute()]));
+//     }),
+//     catchError(() => {
+//       authService.redirectUrl.set(routerState.url);
+//       return of(router.createUrlTree([authService.loginRoute()]));
+//     }),
+//   );


### PR DESCRIPTION
This PR
- [x] Updates the `LoginAuthenticationGuard` to match the Angular documentation's recommendation to not return false and navigate users, but rather return a urlTree

Notes:
I realized Mack placed RequiresCompletedSurveyGuard after the LoginAuthenticationGuard. Looking at the docs it seems like the first guard returning false _should_ [block navigation](https://angular.dev/guide/routing/route-guards#applying-guards-to-routes)

I then realized a couple things

There's another [note in the docs](https://angular.dev/guide/routing/route-guards#canactivate) stating that if we want to redirect users, we should return a URLTree. They don't say what the consequences are though if we don't do this, instead they just say don't do it...
<img width="758" height="56" alt="image" src="https://github.com/user-attachments/assets/261e373c-35fc-4e5d-9c9c-32e5f5c97f0b" />

2. Because the use case here is a user clicking on a SMS link, they will be taken to this page, and if "navigation is cancelled", what happens? I assume Angular falls back to "/" as the default route?
`If all guards return true, navigation continues. If any guard returns false, navigation is cancelled.`
(Answer, I tried this in the "kitchen sink" ccc showcase app, and the page just remain blank, there's nothing displayed if the guard fails and doesn't return a create url tree)