### PR TITLE
fix: add fn overloads for type inferrence of safe http resources

### DIFF
--- a/cmd/pkg/computedresources/weathers.go
+++ b/cmd/pkg/computedresources/weathers.go
@@ -30,7 +30,7 @@ func (w Weather) Resource() accesstypes.Resource {
 }
 
 // The code generator expects the function ReadWeather because its handler is not suppressed on the Weather struct above.
-func ReadWeather(ctx context.Context, loanID ccc.UUID, querySet *resource.QuerySet[Weather], txn resource.ReadOnlyTransaction, client *Client) (*Weather, error) {
+func ReadWeather(ctx context.Context, weatherID ccc.UUID, querySet *resource.QuerySet[Weather], txn resource.ReadOnlyTransaction, client *Client) (*Weather, error) {
 	return nil, nil
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16671,7 +16671,7 @@
     },
     "projects/ccc-lib": {
       "name": "@cccteam/ccc-lib",
-      "version": "0.0.38",
+      "version": "0.0.40",
       "dependencies": {
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",

--- a/projects/ccc-lib/resource-utils/safe-resource.ts
+++ b/projects/ccc-lib/resource-utils/safe-resource.ts
@@ -13,7 +13,7 @@ import { rxResource, RxResourceOptions } from '@angular/core/rxjs-interop';
 import { SwrCacheService } from './swr-cache.service';
 
 export interface SafeResourceRef<T> {
-  safeValue: Signal<T | undefined>;
+  safeValue: Signal<T>;
   resource: ResourceRef<T | undefined>;
 }
 
@@ -25,12 +25,22 @@ export interface SafeResourceRef<T> {
  * into an exception state when the resource.value() is read after it fails to load.
  *
  * If it does not have a value, it will return `undefined` (or the provided `defaultValue` if specified).
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  */
+export function safeHttpResource<T>(
+  url: () => string | undefined,
+  options: HttpResourceOptions<T, unknown> | undefined,
+  defaultValue: T,
+): SafeResourceRef<T>;
+export function safeHttpResource<T>(
+  url: () => string | undefined,
+  options?: HttpResourceOptions<T, unknown>,
+): SafeResourceRef<T | undefined>;
 export function safeHttpResource<T>(
   url: () => string | undefined,
   options?: HttpResourceOptions<T, unknown> | undefined,
   defaultValue?: T,
-): SafeResourceRef<T> {
+): SafeResourceRef<T | undefined> {
   const resource = httpResource<T>(url, options);
   const safeValue = computed(() => {
     if (!resource.hasValue()) {
@@ -48,8 +58,14 @@ export function safeHttpResource<T>(
  * into an exception state when the resource.value() is read after it fails to load.
  *
  * If it does not have a value, it will return `undefined` (or the provided `defaultValue` if specified).
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  */
-export function safeRxResource<T, A = unknown>(options: RxResourceOptions<T, A>, defaultValue?: T): SafeResourceRef<T> {
+export function safeRxResource<T, A = unknown>(options: RxResourceOptions<T, A>, defaultValue: T): SafeResourceRef<T>;
+export function safeRxResource<T, A = unknown>(options: RxResourceOptions<T, A>): SafeResourceRef<T | undefined>;
+export function safeRxResource<T, A = unknown>(
+  options: RxResourceOptions<T, A>,
+  defaultValue?: T,
+): SafeResourceRef<T | undefined> {
   const resource = rxResource<T, A>(options);
 
   const safeValue = computed(() => {
@@ -67,12 +83,22 @@ export function safeRxResource<T, A = unknown>(options: RxResourceOptions<T, A>,
  * The purpose of this utility function is to prevent the resource from dropping the entire application
  * into an exception state when the resource.value() is read after it fails to load, while also preserving the previous value during loading.
  *
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  */
+export function staleHttpResource<T>(
+  url: () => string | undefined,
+  options: HttpResourceOptions<T, unknown> | undefined,
+  defaultValue: T,
+): SafeResourceRef<T>;
+export function staleHttpResource<T>(
+  url: () => string | undefined,
+  options?: HttpResourceOptions<T, unknown>,
+): SafeResourceRef<T | undefined>;
 export function staleHttpResource<T>(
   url: () => string | undefined,
   options?: HttpResourceOptions<T, unknown> | undefined,
   defaultValue?: T,
-): SafeResourceRef<T> {
+): SafeResourceRef<T | undefined> {
   const resource = httpResource<T>(url, options);
   const safeValue = linkedSignal<ResourceSnapshot<T | undefined>, T | undefined>({
     source: resource.snapshot as Signal<ResourceSnapshot<T | undefined>>,
@@ -96,11 +122,14 @@ export function staleHttpResource<T>(
  * The purpose of this utility function is to prevent the resource from dropping the entire application
  * into an exception state when the resource.value() is read after it fails to load, while also preserving the previous value during loading.
  *
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  */
+export function staleRxResource<T, A = unknown>(options: RxResourceOptions<T, A>, defaultValue: T): SafeResourceRef<T>;
+export function staleRxResource<T, A = unknown>(options: RxResourceOptions<T, A>): SafeResourceRef<T | undefined>;
 export function staleRxResource<T, A = unknown>(
   options: RxResourceOptions<T, A>,
   defaultValue?: T,
-): SafeResourceRef<T> {
+): SafeResourceRef<T | undefined> {
   const resource = rxResource<T, A>(options);
 
   const safeValue = linkedSignal<ResourceSnapshot<T | undefined>, T | undefined>({
@@ -127,7 +156,8 @@ export function staleRxResource<T, A = unknown>(
  *
  * When the primary resource's `hasValue()` is false
  * - If the global cache service contains this resource's data, the cached data is immediately returned.
- * - If not in cache, the input `defaultValue` is returned (may be `undefined`)
+ * - If not in cache, the input `defaultValue` is returned
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  *
  * When the primary resource's `hasValue()` is true
  * Once the HTTP resource has data, the `safeValue` signal updates with
@@ -136,9 +166,18 @@ export function staleRxResource<T, A = unknown>(
  */
 export function swrHttpResource<T>(
   urlFn: () => string | undefined,
+  options: HttpResourceOptions<T, unknown> | undefined,
+  defaultValue: T,
+): SafeResourceRef<T>;
+export function swrHttpResource<T>(
+  urlFn: () => string | undefined,
+  options?: HttpResourceOptions<T, unknown>,
+): SafeResourceRef<T | undefined>;
+export function swrHttpResource<T>(
+  urlFn: () => string | undefined,
   options?: HttpResourceOptions<T, unknown> | undefined,
   defaultValue?: T,
-): SafeResourceRef<T> {
+): SafeResourceRef<T | undefined> {
   const cache = inject(SwrCacheService);
   const resource = httpResource<T>(urlFn, options);
 
@@ -180,7 +219,8 @@ export function swrHttpResource<T>(
  *
  * When the primary resource's `hasValue()` is false
  * - If the global cache service contains this resource's data, the cached data is immediately returned.
- * - If not in cache, the input `defaultValue` is returned (may be `undefined`)
+ * - If not in cache, the input `defaultValue` is returned
+ * This setup via function overloading ensures that the returned safeValue will never be undefined if a default is supplied
  *
  * When the primary resource's `hasValue()` is true
  * Once the RxJS resource has data, the `safeValue` signal updates with
@@ -190,8 +230,17 @@ export function swrHttpResource<T>(
 export function swrRxResource<T, A = unknown>(
   cacheKey: string,
   options: RxResourceOptions<T, A>,
+  defaultValue: T,
+): SafeResourceRef<T>;
+export function swrRxResource<T, A = unknown>(
+  cacheKey: string,
+  options: RxResourceOptions<T, A>,
+): SafeResourceRef<T | undefined>;
+export function swrRxResource<T, A = unknown>(
+  cacheKey: string,
+  options: RxResourceOptions<T, A>,
   defaultValue?: T,
-): SafeResourceRef<T> {
+): SafeResourceRef<T | undefined> {
   const cache = inject(SwrCacheService);
   const resource = rxResource<T, A>(options);
   const fullCacheKey = computed(() => {

--- a/projects/showcase-app/src/app/app.routes.ts
+++ b/projects/showcase-app/src/app/app.routes.ts
@@ -20,6 +20,13 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./components/ui/dashboard/dashboard.component').then((comp) => comp.DashboardComponent),
       },
+      {
+        path: 'safe-resource-showcase',
+        loadComponent: () =>
+          import('./components/ui/safe-resource-showcase/safe-resource-showcase.component').then(
+            (comp) => comp.SafeResourceShowcaseComponent,
+          ),
+      },
       resourceRoutes(usersConfig, resourceMeta),
       {
         path: '**',

--- a/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.html
+++ b/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.html
@@ -1,1 +1,9 @@
-<h1>Dashboard</h1>
+<div class="dashboard-container">
+  <h1>Dashboard</h1>
+  <div class="dashboard-item">
+    <p>
+      Tools to help choose the correct network request signal:
+      <a [routerLink]="['/safe-resource-showcase']"> CCC Safe Resource Showcase </a>
+    </p>
+  </div>
+</div>

--- a/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.scss
+++ b/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.scss
@@ -1,0 +1,7 @@
+.dashboard-container {
+  padding: 10px 20px;
+}
+
+.dashboard-item {
+  margin-top: 20px;
+}

--- a/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.ts
+++ b/projects/showcase-app/src/app/components/ui/dashboard/dashboard.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
 })

--- a/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.html
+++ b/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.html
@@ -1,0 +1,183 @@
+<section class="showcase">
+  <header>
+    <h1>Resource Wrapper Showcase</h1>
+    <p>
+      Compare <code>httpResource</code>, <code>rxResource</code>, <code>safe</code>, <code>stale</code>, and
+      <code>swr</code> behaviors across HTTP and RxJS resources.
+      <br />
+      Tip: Open the browser's dev tools and throttle network speed to observe the lifecycle easier
+    </p>
+
+    <div class="controls">
+      <mat-form-field subscriptSizing="dynamic" floatLabel="always">
+        <mat-label>User ID</mat-label>
+        <input
+          matInput
+          type="text"
+          [value]="userId()"
+          (input)="userId.set($any($event.target).value)"
+          placeholder="UUID (leave blank to disable detail calls)" />
+      </mat-form-field>
+
+      <button mat-stroked-button (click)="bumpAll()">
+        <mat-icon>refresh</mat-icon>
+        Reload all
+      </button>
+
+      <button mat-stroked-button (click)="showSwrSection.update((v) => !v)">
+        {{ showSwrSection() ? 'Unmount' : 'Remount' }} SWR section
+      </button>
+
+      <button
+        mat-raised-button
+        [color]="useErrorUrl() ? 'warn' : 'accent'"
+        (click)="toggleErrorUrl()"
+        title="Switches the plain httpResource / rxResource URL to /api/invalid-route-test to trigger a 404">
+        <mat-icon>{{ useErrorUrl() ? 'wifi_off' : 'error_outline' }}</mat-icon>
+        {{ useErrorUrl() ? 'Restore URL' : 'Simulate Error' }}
+      </button>
+    </div>
+  </header>
+
+  <!-- ============ PLAIN (comparison) ============ -->
+  <article class="card">
+    <h2>httpResource <small>(list)</small></h2>
+    <p class="desc">
+      Standard Angular <code>httpResource</code>. Value becomes <code>undefined</code> on error — accessing
+      <code>value()</code> in an error state throws.
+    </p>
+    <div class="status">
+      <span
+        >status: <strong>{{ plainHttpList.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ plainHttpList.hasValue() }}</strong></span
+      >
+      <span
+        >count: <strong>{{ plainHttpList.hasValue() ? plainHttpList.value()!.length : '—' }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="plainHttpList.reload()">Reload</button>
+    </div>
+    <pre>{{ plainHttpList.hasValue() ? (plainHttpList.value() | json) : plainHttpList.status() }}</pre>
+  </article>
+
+  <article class="card">
+    <h2>rxResource <small>(detail)</small></h2>
+    <p class="desc">
+      Standard Angular <code>rxResource</code>. No default supplied — typed <code>User | undefined</code>. Accessing
+      <code>value()</code> in an error state throws.
+    </p>
+    <div class="status">
+      <span
+        >status: <strong>{{ plainRxDetail.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ plainRxDetail.hasValue() }}</strong></span
+      >
+      <span
+        >value: <strong>{{ plainRxDetail.hasValue() ? (plainRxDetail.value()?.username ?? '—') : '—' }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="plainRxDetail.reload()" [disabled]="!detailUrl()">Reload</button>
+    </div>
+    <pre>{{ plainRxDetail.hasValue() ? (plainRxDetail.value() | json) : plainRxDetail.status() }}</pre>
+  </article>
+
+  <!-- ============ SAFE ============ -->
+  <article class="card">
+    <h2>safeHttpResource <small>(list)</small></h2>
+    <p class="desc">Clears to <code>defaultValue</code> (empty array) while loading. No previous value retained.</p>
+    <div class="status">
+      <span
+        >status: <strong>{{ safeHttpList.resource.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ safeHttpList.resource.hasValue() }}</strong></span
+      >
+      <span
+        >count: <strong>{{ safeHttpList.safeValue().length }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="safeHttpList.resource.reload()">Reload</button>
+    </div>
+    <pre>{{ safeHttpList.safeValue() | json }}</pre>
+  </article>
+
+  <article class="card">
+    <h2>safeRxResource <small>(detail)</small></h2>
+    <p class="desc">No default supplied → <code>safeValue()</code> is typed <code>User | undefined</code>.</p>
+    <div class="status">
+      <span
+        >status: <strong>{{ safeRxDetail.resource.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ safeRxDetail.resource.hasValue() }}</strong></span
+      >
+      <span
+        >value: <strong>{{ safeRxDetail.safeValue()?.username ?? '—' }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="safeRxDetail.resource.reload()" [disabled]="!userId()">Reload</button>
+    </div>
+    <pre>{{ safeRxDetail.safeValue() | json }}</pre>
+  </article>
+
+  <!-- ============ STALE ============ -->
+  <article class="card">
+    <h2>staleHttpResource <small>(list)</small></h2>
+    <p class="desc">
+      Holds previous value during reload. Watch the count stay stable while status flips to <code>reloading</code>.
+    </p>
+    <div class="status">
+      <span
+        >status: <strong>{{ staleHttpList.resource.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ staleHttpList.resource.hasValue() }}</strong></span
+      >
+      <span
+        >count: <strong>{{ staleHttpList.safeValue().length }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="staleHttpList.resource.reload()">Reload</button>
+    </div>
+    <pre>{{ staleHttpList.safeValue() | json }}</pre>
+  </article>
+
+  <article class="card">
+    <h2>staleRxResource <small>(detail)</small></h2>
+    <p class="desc">Same as above but via <code>rxResource</code>. No default → typed <code>User | undefined</code>.</p>
+    <div class="status">
+      <span
+        >status: <strong>{{ staleRxDetail.resource.status() }}</strong></span
+      >
+      <span
+        >hasValue: <strong>{{ staleRxDetail.resource.hasValue() }}</strong></span
+      >
+      <span
+        >value: <strong>{{ staleRxDetail.safeValue()?.username }}</strong></span
+      >
+    </div>
+    <div class="actions">
+      <button mat-stroked-button (click)="staleRxDetail.resource.reload()" [disabled]="!userId()">Reload</button>
+    </div>
+    <pre>{{ staleRxDetail.safeValue() | json }}</pre>
+  </article>
+
+  <!-- ============ SWR (mountable) ============ -->
+  @if (showSwrSection()) {
+    <app-swr-section [userId]="userId()" />
+  } @else {
+    <article class="card unmounted">
+      <p>
+        SWR section unmounted. Click "Remount SWR section" to bring it back — values should appear instantly from cache.
+      </p>
+    </article>
+  }
+</section>

--- a/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.scss
+++ b/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.scss
@@ -1,0 +1,70 @@
+.showcase {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+.card {
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--mat-sys-outline-variant, #ddd);
+  border-radius: 0.5rem;
+  position: relative;
+  margin-top: 0.5rem;
+}
+
+.card.unmounted {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-block: 0.75rem;
+}
+
+.status {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-block: 0.5rem;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-block: 0.5rem;
+}
+
+.desc {
+  font-size: 0.9rem;
+  color: var(--mat-sys-on-surface-variant, #555);
+  margin-block: 0.25rem 0.75rem;
+}
+
+pre {
+  background: var(--mat-sys-surface-container, #f5f5f5);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  max-height: 12rem;
+  overflow: auto;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+h2 {
+  margin: 0;
+}
+
+h2 small {
+  font-weight: normal;
+  color: var(--mat-sys-on-surface-variant, #777);
+  font-size: 0.85rem;
+}

--- a/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.spec.ts
+++ b/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SafeResourceShowcaseComponent } from './safe-resource-showcase.component';
+
+describe('SafeResourceShowcaseComponent', () => {
+  let component: SafeResourceShowcaseComponent;
+  let fixture: ComponentFixture<SafeResourceShowcaseComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SafeResourceShowcaseComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SafeResourceShowcaseComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.ts
+++ b/projects/showcase-app/src/app/components/ui/safe-resource-showcase/safe-resource-showcase.component.ts
@@ -1,0 +1,78 @@
+import { JsonPipe } from '@angular/common';
+import { HttpClient, httpResource } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import {
+  safeHttpResource,
+  safeRxResource,
+  staleHttpResource,
+  staleRxResource,
+} from '@cccteam/ccc-lib/resource-utils/safe-resource';
+import { Users } from '../../../core/generated/zz_gen_resources';
+import { SwrSectionComponent } from './swr-section.component';
+
+@Component({
+  selector: 'app-resource-showcase',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './safe-resource-showcase.component.html',
+  styleUrl: './safe-resource-showcase.component.scss',
+  imports: [JsonPipe, SwrSectionComponent, MatButtonModule, MatFormFieldModule, MatInputModule, MatIconModule],
+})
+export class SafeResourceShowcaseComponent {
+  private readonly http = inject(HttpClient);
+
+  readonly userId = signal('');
+  readonly showSwrSection = signal(true);
+  readonly useErrorUrl = signal(false);
+
+  readonly listUrl = computed(() => (this.useErrorUrl() ? '/api/invalid-route-test' : '/api/users'));
+  readonly detailUrl = computed(() => {
+    if (this.useErrorUrl()) return '/api/invalid-route-test';
+    return this.userId() ? `/api/users/${this.userId()}` : undefined;
+  });
+
+  // --- plain Angular variants (for comparison) ---
+  readonly plainHttpList = httpResource<Users[]>(() => this.listUrl());
+
+  // params is typed as `string` so the stream receives a non-undefined value;
+  // rxResource only invokes the stream when params() is not undefined.
+  readonly plainRxDetail = rxResource<Users, string | undefined>({
+    params: () => this.detailUrl(),
+    stream: ({ params }) => this.http.get<Users>(params),
+  });
+
+  // --- safe variants ---
+  readonly safeHttpList = safeHttpResource<Users[]>(() => '/api/users', undefined, []);
+
+  readonly safeRxDetail = safeRxResource<Users>({
+    params: () => (this.userId() ? this.userId() : undefined),
+    stream: ({ params }) => this.http.get<Users>(`/api/users/${params}`),
+  });
+
+  // --- stale variants ---
+  readonly staleHttpList = staleHttpResource<Users[]>(() => '/api/users', undefined, []);
+
+  readonly staleRxDetail = staleRxResource<Users>({
+    params: () => (this.userId() ? this.userId() : undefined),
+    stream: ({ params }) => this.http.get<Users>(`/api/users/${params}`),
+  });
+
+  toggleErrorUrl(): void {
+    this.useErrorUrl.update((v) => !v);
+  }
+
+  bumpAll(): void {
+    this.plainHttpList.reload();
+    this.safeHttpList.resource.reload();
+    this.staleHttpList.resource.reload();
+    if (this.userId()) {
+      this.plainRxDetail.reload();
+      this.safeRxDetail.resource.reload();
+      this.staleRxDetail.resource.reload();
+    }
+  }
+}

--- a/projects/showcase-app/src/app/components/ui/safe-resource-showcase/swr-section.component.ts
+++ b/projects/showcase-app/src/app/components/ui/safe-resource-showcase/swr-section.component.ts
@@ -1,0 +1,59 @@
+import { JsonPipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { swrHttpResource, swrRxResource } from '@cccteam/ccc-lib/resource-utils/safe-resource';
+import { Users } from '../../../core/generated/zz_gen_resources';
+
+@Component({
+  selector: 'app-swr-section',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <article class="card">
+      <h2>swrHttpResource <small>(list)</small></h2>
+      <p class="desc">
+        On mount: cached value appears immediately, then fresh data replaces it. Try unmounting and remounting the
+        section — the list shows up instantly the second time.
+      </p>
+      <div class="status">
+        <span>status: <strong>{{ swrHttpList.resource.status() }}</strong></span>
+        <span>hasValue: <strong>{{ swrHttpList.resource.hasValue() }}</strong></span>
+        <span>count: <strong>{{ swrHttpList.safeValue().length }}</strong></span>
+      </div>
+      <div class="actions">
+        <button mat-stroked-button (click)="swrHttpList.resource.reload()">Reload</button>
+      </div>
+      <pre>{{ swrHttpList.safeValue() | json }}</pre>
+    </article>
+
+    <article class="card">
+      <h2>swrRxResource <small>(detail)</small></h2>
+      <p class="desc">
+        Cache key is required since the URL is not derivable from the wrapper's inputs. No default → typed
+        <code>User | undefined</code>.
+      </p>
+      <div class="status">
+        <span>status: <strong>{{ swrRxDetail.resource.status() }}</strong></span>
+        <span>hasValue: <strong>{{ swrRxDetail.resource.hasValue() }}</strong></span>
+        <span>value: <strong>{{ swrRxDetail.safeValue()?.username ?? '—' }}</strong></span>
+      </div>
+      <div class="actions">
+        <button mat-stroked-button (click)="swrRxDetail.resource.reload()" [disabled]="!userId()">Reload</button>
+      </div>
+      <pre>{{ swrRxDetail.safeValue() | json }}</pre>
+    </article>
+  `,
+  styleUrl: './safe-resource-showcase.component.scss',
+  imports: [JsonPipe, MatButtonModule],
+})
+export class SwrSectionComponent {
+  private readonly http = inject(HttpClient);
+  readonly userId = input.required<string>();
+
+  readonly swrHttpList = swrHttpResource<Users[]>(() => '/api/users', undefined, []);
+
+  readonly swrRxDetail = swrRxResource<Users>('user-detail', {
+    params: () => (this.userId() ? this.userId() : undefined),
+    stream: ({ params }) => this.http.get<Users>(`/api/users/${params}`),
+  });
+}


### PR DESCRIPTION
This PR:

- [x] Adds function overloads to allow consumers to infer that an swr resource with a default provided will never be undefined, and one that has no default could be `T | undefined`