### PR TITLE
fix: ccc-grid filter menu interactions and sizing

### DIFF
--- a/projects/ccc-lib/ccc-grid/ccc-grid.component.html
+++ b/projects/ccc-lib/ccc-grid/ccc-grid.component.html
@@ -52,18 +52,23 @@
               @if (col.resizable ?? true) {
                 <span class="resize-handle" (mousedown)="startResize($event, col)"></span>
               }
-              <mat-menu #filterMenu="matMenu">
+              <mat-menu #filterMenu="matMenu" class="ccc-grid-filter-menu">
                 <div class="filter-menu-content">
                   <select
                     class="filter-operator"
                     [value]="filterOperator(col)"
                     (change)="setFilterOperator(col, $event)"
+                    (click)="$event.stopPropagation()"
+                    (keydown)="$event.stopPropagation()"
                     aria-label="Filter operator">
                     @for (op of filterOperators; track op.value) {
                       <option [value]="op.value">{{ op.label }}</option>
                     }
                   </select>
-                  <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                  <mat-form-field
+                    appearance="outline"
+                    subscriptSizing="dynamic"
+                    (click)="$event.stopPropagation()">
                     <input
                       matInput
                       placeholder="Value"

--- a/projects/ccc-lib/ccc-grid/ccc-grid.component.html
+++ b/projects/ccc-lib/ccc-grid/ccc-grid.component.html
@@ -32,7 +32,9 @@
                       <span class="col-header">{{ col.header || col.id | camelCaseToTitle }}</span>
                     }
                     @if (sortInfo(col); as sort) {
-                      <mat-icon class="sort-icon">{{ sort.direction === 'asc' ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
+                      <mat-icon class="sort-icon">{{
+                        sort.direction === 'asc' ? 'arrow_upward' : 'arrow_downward'
+                      }}</mat-icon>
                       @if (hasMultipleSorts()) {
                         <span class="sort-priority">{{ sort.priority }}</span>
                       }
@@ -52,7 +54,7 @@
               @if (col.resizable ?? true) {
                 <span class="resize-handle" (mousedown)="startResize($event, col)"></span>
               }
-              <mat-menu #filterMenu="matMenu" class="ccc-grid-filter-menu">
+              <mat-menu #filterMenu="matMenu" class="ccc-grid-filter-menu" (closed)="clearEmptyFilter(col)">
                 <div class="filter-menu-content">
                   <select
                     class="filter-operator"
@@ -65,10 +67,7 @@
                       <option [value]="op.value">{{ op.label }}</option>
                     }
                   </select>
-                  <mat-form-field
-                    appearance="outline"
-                    subscriptSizing="dynamic"
-                    (click)="$event.stopPropagation()">
+                  <mat-form-field appearance="outline" subscriptSizing="dynamic" (click)="$event.stopPropagation()">
                     <input
                       matInput
                       placeholder="Value"

--- a/projects/ccc-lib/ccc-grid/ccc-grid.component.scss
+++ b/projects/ccc-lib/ccc-grid/ccc-grid.component.scss
@@ -222,6 +222,10 @@
   max-width: 100%;
 
   mat-form-field {
+    --mat-form-field-container-height: 28px;
+    --mat-form-field-container-text-size: 13px;
+    --mat-form-field-container-vertical-padding: 2px;
+
     width: 140px;
   }
 

--- a/projects/ccc-lib/ccc-grid/ccc-grid.component.scss
+++ b/projects/ccc-lib/ccc-grid/ccc-grid.component.scss
@@ -60,6 +60,13 @@
   padding: 8px;
 }
 
+// The filter form is wider than Material's 280px menu cap. The panel renders in the
+// document-level overlay container, so this component style must cross encapsulation.
+::ng-deep .mat-mdc-menu-panel.ccc-grid-filter-menu {
+  width: max-content;
+  max-width: calc(100vw - 32px);
+}
+
 .header-cell .filter-trigger.mat-mdc-icon-button {
   --mdc-icon-button-state-layer-size: 22px;
   --mat-icon-button-state-layer-size: 22px;
@@ -211,6 +218,8 @@
   align-items: center;
   gap: 6px;
   padding: 8px 12px;
+  width: max-content;
+  max-width: 100%;
 
   mat-form-field {
     width: 140px;

--- a/projects/ccc-lib/ccc-grid/ccc-grid.component.ts
+++ b/projects/ccc-lib/ccc-grid/ccc-grid.component.ts
@@ -349,11 +349,7 @@ export class AppGridComponent {
   setFilterValue(col: ColumnConfig, event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     const next = { ...this.filters() };
-    if (value) {
-      next[col.id] = { operator: this.filterOperator(col), value };
-    } else {
-      delete next[col.id];
-    }
+    next[col.id] = { operator: this.filterOperator(col), value };
     this.filters.set(next);
     this.pageIndex.set(0);
   }
@@ -365,6 +361,12 @@ export class AppGridComponent {
     const next = { ...this.filters() };
     delete next[col.id];
     this.filters.set(next);
+  }
+
+  clearEmptyFilter(col: ColumnConfig): void {
+    if (!this.hasFilter(col)) {
+      this.clearFilter(col);
+    }
   }
 
   widthFor(col: ColumnConfig): number | null {


### PR DESCRIPTION
## Summary

- keep the filter operator and value controls interactive inside the Angular Material menu
- isolate operator keyboard events from the menu key manager
- give the filter panel an intrinsic, viewport-bounded width
- leave the Clear button unguarded so it continues to close the menu

## Context

`ccc-grid` uses `mat-menu` as a form popover. Angular Material treats it as a command menu: the panel closes whenever a click bubbles to it. As a result, clicking the filter value input focused it briefly, then closed the overlay and restored focus to the trigger. The operator select had the same click problem, and its keyboard events also reached Material's menu key manager.

The fix stops click propagation at the select and form-field boundaries and stops keydown propagation on the select, matching the value input's existing keyboard isolation. The event guard is intentionally not placed on the entire filter container so the Clear action retains the existing close behavior.

Angular Material 21.2.x also caps menu panels at `280px`. That compresses this filter form and can collapse the intended `140px` value field to roughly `30px`. A panel class now opts this menu into intrinsic sizing while bounding it to the viewport. The overlay rule uses `::ng-deep` because Material renders the panel in the document-level CDK overlay container rather than beneath the component host.

## Validation

- `bun run build`
- browser verification on the grid showcase:
  - clicking and typing in the value input keeps the menu open and focus in the input
  - desktop panel and content settle at approximately `390px` with no overflow
  - at a `360px` viewport, the panel remains bounded to `328px`